### PR TITLE
OSX port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 .obj
 .moc
 .qmake.stash
+.vs
+dynablaster.vcxproj*
+dynablaster.sln
 dynablaster.app
 Makefile
+Makefile.Debug
+Makefile.Release
+debug
+release

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.obj
+.moc
+.qmake.stash
+dynablaster.app
+Makefile

--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ qmake
 jom
 ```
 
+### Building on OSX
+
+First ensure Xcode (10.1 was used) and command line build tools are installed.
+
+Install dependencies (using Homebrew):
+```
+brew install qt5
+brew install sdl2
+```
+
+Add Qt5 to `~/.bash_profile` so qmake can be found:
+```
+export PATH="$(brew --prefix qt5)/bin:$PATH"
+```
+
+Build client:
+```
+cd client
+qmake
+make -j8
+```
+
 # Requirements
 
 To run the game you need a video-card with OpenGL 3.0 support and at least

--- a/client/client.pro
+++ b/client/client.pro
@@ -20,9 +20,14 @@ win32 {
    RC_FILE = dynablaster.rc
 }
 
-unix {
+unix:!macx {
    LIBS += -lasound
    DEFINES += _LINUX_
+}
+
+macx {
+   LIBS += -L/usr/local/opt/sdl2/lib -framework CoreAudio -framework AudioToolbox
+   DEFINES += __APPLE__
 }
 
 #QMAKE_CFLAGS_RELEASE += -Zi

--- a/client/src/framework/gldevice.cpp
+++ b/client/src/framework/gldevice.cpp
@@ -239,6 +239,7 @@ bool GLDevice::init()
    mTotalTextureMemory= 0;
    mTotalVertexMemory= 0;
    for (int i=0;i<256;i++) keys[i]=0;
+   mShaderAllocIndex= 0;
 
    if (!initExtensions())
    {
@@ -870,7 +871,8 @@ unsigned int GLDevice::loadShader(const char *vname, const char *pname)
       qDebug("shader file not found!");
    }
 
-   unsigned int shader= (unsigned int)prog;
+   unsigned int shader = mShaderAllocIndex++;
+   mShaderTable[shader] = prog;
    setShader(shader);
 
    return shader;
@@ -882,13 +884,15 @@ void GLDevice::setShader(unsigned int shader)
    if (mCurShader != shader)
    {
       mCurShader= shader;
-      glUseProgramObject( (ShaderProgramHandle)mCurShader );
+      ShaderProgramHandle prog = mShaderTable[mCurShader];
+      glUseProgramObject(prog);
    }
 }
 
 int GLDevice::getParameterIndex(const char *name)
 {
-   int pos= glGetUniformLocation(mCurShader, name);
+   ShaderProgramHandle prog = mShaderTable[mCurShader];
+   int pos= glGetUniformLocation(prog, name);
    GLenum error = glGetError();
    if (error!=GL_NO_ERROR)
    {

--- a/client/src/framework/gldevice.cpp
+++ b/client/src/framework/gldevice.cpp
@@ -121,7 +121,7 @@ void* getProcAddress(const char *name, bool optional = false)
 #endif
 
 #ifdef Q_OS_MAC
-   ptr=(void*)glutGetProcAddress(name);
+//   ptr=(void*)glutGetProcAddress(name);
 #endif
 
 

--- a/client/src/framework/gldevice.cpp
+++ b/client/src/framework/gldevice.cpp
@@ -871,7 +871,7 @@ unsigned int GLDevice::loadShader(const char *vname, const char *pname)
       qDebug("shader file not found!");
    }
 
-   unsigned int shader = mShaderAllocIndex++;
+   unsigned int shader = ++mShaderAllocIndex;
    mShaderTable[shader] = prog;
    setShader(shader);
 

--- a/client/src/framework/gldevice.h
+++ b/client/src/framework/gldevice.h
@@ -74,6 +74,9 @@ private:
    bool       initExtensions();
    unsigned int mTexture;
 
+   std::map<unsigned int, GLhandleARB>  mShaderTable;
+   unsigned int                         mShaderAllocIndex;
+
 public:
    bool init();
 

--- a/client/src/game/bombermanview.cpp
+++ b/client/src/game/bombermanview.cpp
@@ -112,6 +112,10 @@ GameView::GameView(QWidget *parent, const QGLFormat& format)
    {
       mDevicePixelRatio = 2;
    }
+#ifdef Q_OS_MAC
+   // TODO: hardcoded to support Retina displays
+   mDevicePixelRatio = 2;
+#endif
 
    GameSettings::VideoSettings* video=
       GameSettings::getInstance()->getVideoSettings();

--- a/client/src/game/videooptions.cpp
+++ b/client/src/game/videooptions.cpp
@@ -89,6 +89,7 @@ void VideoOptions::initializeSamples()
    GLenum internalFormat = GL_RGBA;
    GLint samplesLength = 0;
 
+#ifndef Q_OS_MAC
    // check if extension is available
    if (glGetInternalformativ)
    {
@@ -126,6 +127,7 @@ void VideoOptions::initializeSamples()
          delete[] samples;
       }
    }
+#endif
 
    if (samplesLength == 0)
    {

--- a/client/src/mp3/mpegstream.cpp
+++ b/client/src/mp3/mpegstream.cpp
@@ -1086,7 +1086,7 @@ read_again:
       This is essential to prevent endless looping, always going back to the beginning when feeder buffer is exhausted. */
    forget();
 
-   debug2("trying to get frame %"OFF_P" at %"OFF_P, (off_p)mFrameNum+1, (off_p)tell());
+   debug2("trying to get frame %" OFF_P " at %" OFF_P, (off_p)mFrameNum+1, (off_p)tell());
    if (!head_read(&newhead))
    {
       ret= MP3_DONE;
@@ -1274,7 +1274,7 @@ int MpegStream::skip_junk(unsigned long *newheadp, long *headcount)
    }
    else
    {
-      debug1("hopefully found one at %"OFF_P, (off_p)tell());
+      debug1("hopefully found one at %" OFF_P, (off_p)tell());
    }
 
    /* If the new header ist good, it is already decoded. */

--- a/client/src/tools/stdafx.h
+++ b/client/src/tools/stdafx.h
@@ -12,7 +12,6 @@
 #endif
 
 #include <math.h>
-#include <malloc.h>
 #include <memory.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
This quickly done patch adds support to build Dynablaster Revenge for Mac OS X.

Most of the code worked as-is, however a shader LUT was required to convert between the engine's unsigned int type and a GLhandleARB, as OSX shader program handles will not fit in an unsigned int type.

The only other fix was to set the device pixel ratio to 2.0 to support Retina displays (although this is hardcoded for now).

I've also added some simple directions to compile and build to the README.md.

If you'd like a unified patch instead, please let me know!